### PR TITLE
Fix type specs

### DIFF
--- a/lib/wpcom/call.ex
+++ b/lib/wpcom/call.ex
@@ -7,7 +7,7 @@ defmodule Wpcom.Call do
   @spec get(
           String.t(),
           [{String.t(), String.t()}]
-        ) :: {:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}
+        ) :: {:error, any()} | {:ok, any()}
   def get(path, headers \\ []) do
     Wpcom.Req.request(:get, path, headers)
   end
@@ -17,7 +17,7 @@ defmodule Wpcom.Call do
           String.t(),
           %{} | String.t(),
           [{String.t(), String.t()}]
-        ) :: {:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}
+        ) :: {:error, any()} | {:ok, any()}
   def post(path, body, headers \\ []) do
     Wpcom.Req.request(:post, path, headers, body)
   end
@@ -27,7 +27,7 @@ defmodule Wpcom.Call do
           String.t(),
           %{} | String.t(),
           [{String.t(), String.t()}]
-        ) :: {:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}
+        ) :: {:error, any()} | {:ok, any()}
   def put(path, body, headers \\ []) do
     post(path, body, headers)
   end
@@ -36,7 +36,7 @@ defmodule Wpcom.Call do
   @spec del(
           String.t(),
           [{String.t(), String.t()}]
-        ) :: {:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}
+        ) :: {:error, any()} | {:ok, any()}
   def del(path, headers) do
     post(path, "", headers)
   end

--- a/lib/wpcom/req.ex
+++ b/lib/wpcom/req.ex
@@ -11,14 +11,14 @@ defmodule Wpcom.Req do
   def request(method, path, custom_headers \\ [], body \\ "")
 
   @spec request(:get | :post, String.t(), [{String.t(), String.t()}], %{}) ::
-          {:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}
+          {:error, any()} | {:ok, any()}
   def request(method, path, custom_headers, body) when is_map(body) do
     headers = custom_headers ++ [{"Content-Type", "application/json"}]
     request(method, path, headers, Jason.encode!(body))
   end
 
   @spec request(:get | :post, String.t(), [{String.t(), String.t()}], String.t()) ::
-          {:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}
+          {:error, any()} | {:ok, any()}
   def request(method, path, custom_headers, body) do
     headers = custom_headers ++ [{"User-Agent", "wpcom.ex/" <> version()}]
 


### PR DESCRIPTION
The `request` method actually returns the `HTTPoison.Response`'s body for success which has type `any()` and `HTTPoison.Error`'s reason for error which also has the type `any()`