### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. (Dependabot github-actions ecosystem already configured in this repo; left as-is.)

Tracking: DEVPROD-1072.
